### PR TITLE
Fix incompatibility to new scijava LogService

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,7 @@
 		<license.copyrightOwners>Board of Regents of the University of
 Wisconsin-Madison.</license.copyrightOwners>
 		<license.projectName>SciJava SLF4J-based logging implementation.</license.projectName>
+		<scijava-common.version>2.67.0</scijava-common.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -102,5 +102,18 @@ Wisconsin-Madison.</license.copyrightOwners>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
+
+
+		<!-- Test dependencies -->
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/src/test/java/org/scijava/log/slf4j/SLF4JLogServiceTest.java
+++ b/src/test/java/org/scijava/log/slf4j/SLF4JLogServiceTest.java
@@ -1,0 +1,89 @@
+package org.scijava.log.slf4j;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import ch.qos.logback.core.AppenderBase;
+import org.junit.Before;
+import org.junit.Test;
+import org.scijava.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class SLF4JLogServiceTest {
+
+	private SLF4JLogService log;
+	private RecordingAppender recorder;
+	private final String MESSAGE_TEXT = "Message logged as part of a unit test";
+
+	@Before
+	public void before() {
+		Context context = new Context(SLF4JLogService.class);
+		log = context.service(SLF4JLogService.class);
+		recorder = new RecordingAppender(log.getLogger());
+	}
+
+	@Test
+	public void testMessageLogging() {
+		recorder.clear();
+		log.info(MESSAGE_TEXT);
+		ILoggingEvent event = recorder.getLastEvent();
+		assertTrue(event.getMessage().contains(MESSAGE_TEXT));
+		assertEquals(Level.INFO, event.getLevel());
+	}
+
+	@Test
+	public void testSubLogger() {
+		recorder.clear();
+		String source = "one:two:three";
+		log.subLogger(source).warn(MESSAGE_TEXT);
+		ILoggingEvent event = recorder.getLastEvent();
+		assertTrue(event.getMessage().contains(source));
+	}
+
+	@Test
+	public void testLoggingThrowable() {
+		recorder.clear();
+		Throwable throwable = new Throwable("Throwable logged as part of a unit test");
+		log.info(throwable);
+		ILoggingEvent event = recorder.getLastEvent();
+		assertEquals(throwable.getMessage(), event.getThrowableProxy().getMessage());
+	}
+
+	private static class RecordingAppender {
+
+		private ILoggingEvent lastEvent = null;
+
+		public RecordingAppender(Logger slf4jLogger) {
+			LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
+			Appender<ILoggingEvent> appender = new AppenderBase<ILoggingEvent>() {
+				@Override
+				protected void append(ILoggingEvent event) {
+					lastEvent = event;
+				}
+			};
+			appender.setContext(lc);
+			appender.setName("test_recorder");
+			appender.start();
+			lc.getLogger(slf4jLogger.getName()).addAppender(appender);
+		}
+
+		public void clear() {
+			lastEvent = null;
+		}
+
+		public ILoggingEvent getLastEvent() {
+			if(!hasLastEvent())
+				throw new IllegalStateException("No log message recorded.");
+			return lastEvent;
+		}
+
+		private boolean hasLastEvent() {
+			return lastEvent != null;
+		}
+	}
+}


### PR DESCRIPTION
Add implementations for the methods that were recently added to LogService.

A new version of scijva-log-slf4j containing this changes should be released together with scijava-common 2.66.2.